### PR TITLE
Update pinned helm-charts version to fix issues

### DIFF
--- a/training/2. Grey Matter Installation/Grey Matter Installation Training.md
+++ b/training/2. Grey Matter Installation/Grey Matter Installation Training.md
@@ -138,7 +138,7 @@ sudo helm repo update
 And now, the moment we've all been waiting for... We will use the two configuration override files we created earlier to install Grey Matter. We'll start with the `--dry-run` flag to check our configs _only_, then remove it to do the actual installation.
 
 ``` bash
-sudo helm install decipher/greymatter -f greymatter.yaml -f greymatter-secrets.yaml --name gm --version 2.0.4 --dry-run
+sudo helm install decipher/greymatter -f greymatter.yaml -f greymatter-secrets.yaml --name gm --version 2.1.5 --dry-run
 ```
 
 If you see no errors with `--dry-run`, and all you see is `NAME: gm`, then it's safe to remove `--dry-run` flag and re-run. Do so now.

--- a/training/2. Grey Matter Installation/Grey Matter Installation Training.md
+++ b/training/2. Grey Matter Installation/Grey Matter Installation Training.md
@@ -17,7 +17,8 @@ Begin by launching a
 
 1. the default Ubuntu Server AMI 
 2. into a t2.2xlarge
-3. with 32 GB storage (the default is 8).
+3. with 32 GB storage (the default is 8)
+4. and TCP port `30000` open in its security group.
 
 Leave all other parameters set to their defaults, including the default security group. (We will update it later once we know what port to use.)
 
@@ -152,23 +153,9 @@ watch sudo kubectl get pods
 
 Don't worry if you see `Error` and `CrashLoopBackOff`. This is normal, as each component of the system retries until its dependencies are available. `catalog-init` especially takes a while to execute without error.
 
-Once everything is either `Running` or `Completed`, Grey Matter is up and we have only to open the ingress port before we can connect from the outside. You can discover the ingress port with
+Once everything is either `Running` or `Completed`, Grey Matter is up and running.
 
-``` bash
-sudo minikube service list
-```
-
-which should result in something like the following. Copy the  first `voyager-edge` port so we can add it to the AWS Security Group for our EC2 instance. 
-
-![Find voyager-edge port](./1571947975787.png)
-
-> NOTE: This is the _port_ you'll need, but the IP address listed there is your Minikube-internal IP address, and won't work for access from the outside. Replace this with your EC2's public IP to access Grey Matter from the browser.
-
-Now add an inbound TCP rule for that port to the security group for your EC2. This is done in the AWS console.
-
-![Add port to security group](./1571948050321.png)
-
-The last bit of setup necessary is to add the Grey Matter quickstart certificate to your _local machine's_ browser/keychain. The exact steps differ between operating systems and browsers, but for Chrome you should be able to simply [download `quickstart.zip` from here](https://drive.google.com/open?id=1YEyw5vEHrXhDpGuDk9RHQcQk5kFk38uz), extract the certificates, and double-click on `quickstart.p12` to import it into your OS' keychain. The password is `password`.
+The last bit of setup necessary before we can see the dashboard is to add the Grey Matter quickstart certificate to your _local machine's_ browser/keychain. The exact steps differ between operating systems and browsers, but for Chrome you should be able to simply [download `quickstart.zip` from here](https://drive.google.com/open?id=1YEyw5vEHrXhDpGuDk9RHQcQk5kFk38uz), extract the certificates, and double-click on `quickstart.p12` to import it into your OS' keychain. The password is `password`.
 
 If you are certain that you have installed the certificate correctly, and yet Chrome/Chromium still won't let you open the page, especially on a Linux machine, there is a trick for bypassing the security check and getting to the page: Click anywhere on the warning page, and type (nowhere in particular) "thisisinsecure". This may work when all other attempts fail.
 
@@ -176,7 +163,7 @@ For Firefox, you can import the certificate directly into the browser from the C
 
 > NOTE: In actual production deployments, you would be replacing the entire PKI certificate setup (in greymatter-secrets.yaml) with a secure one. The provided quickstart certificates are for demonstration purposes only.
 
-Finally, navigate to `https://{your-ec2-public-ip}:{voyager-edge-port}`. Your browser will complain that the certificate is untrusted, but you may safely ignore that for now. Proceed with temporarily trusting the quickstart self-signed certificates. You should see your very own instances of the Grey Matter Intel 360 Dashboard, showing the seven core Grey Matter services.
+Finally, navigate to `https://{your-ec2-public-ip}:30000`. Your browser will complain that the certificate is untrusted, but you may safely ignore that for now. Proceed with temporarily trusting the quickstart self-signed certificates. You should see your very own instances of the Grey Matter Intel 360 Dashboard, showing the seven core Grey Matter services.
 
 ![Intel 360 Dashboard](./1571945172857.png)
 

--- a/training/3. Grey Matter Service Deployment/Grey Matter Service Deployment Training.md
+++ b/training/3. Grey Matter Service Deployment/Grey Matter Service Deployment Training.md
@@ -39,7 +39,7 @@ We begin by configuring the CLI to connect to the Control API:
 ``` bash
 # A convenient trick for discovering your EC2's host and port
 export HOST=$( curl -s http://169.254.169.254/latest/meta-data/public-ipv4 )
-export PORT=$( sudo minikube service list | grep voyager-edge | grep -oP ':\K(\d+)' )
+export PORT=30000
 
 echo https://$HOST:$PORT
 
@@ -533,7 +533,7 @@ If you don't see any of the above variables, or some variables are missing, reru
 
 ```bash
 export HOST=$( curl -s http://169.254.169.254/latest/meta-data/public-ipv4 )
-export PORT=$( sudo minikube service list | grep voyager-edge | grep -oP ':\K(\d+)' )
+export PORT=30000
 export GREYMATTER_API_HOST="$HOST:$PORT"
 export GREYMATTER_API_PREFIX='/services/gm-control-api/latest'
 export GREYMATTER_API_SSLCERT="/etc/ssl/quickstart/certs/quickstart.crt"
@@ -551,7 +551,7 @@ Run `greymatter` again, if everything looks correct try your command again.  If 
     list: could not successfully make request to https://:443/services/gm-control-api/latest/v1.0/cluster?filters=%5B%7B%22cluster_key%22%3A%22%22%2C%22name%22%3A%22%22%2C%22zone_key%22%3A%22%22%2C%22org_key%22%3A%22%22%7D%5D: Get https://:443/services/gm-control-api/latest/v1.0/cluster?filters=%5B%7B%22cluster_key%22%3A%22%22%2C%22name%22%3A%22%22%2C%22zone_key%22%3A%22%22%2C%22org_key%22%3A%22%22%7D%5D: dial tcp :443: connect: connection refused
     ```
 
-    `GREYMATTER_API_HOST` is likely incorrectly configured. Run `echo $GREYMATTER_API_HOST`, then run `sudo minikube service list` and check that one of the ports listed in voyager-edge matches the port at the end of your variable.  If it doesn't match either voyager-edge port copy the first port and run `export PORT={your-voyager-edge-port}`.  If one of them does match, copy the other port and `export PORT={your-voyager-edge-port}`.  Then run the following,
+    `GREYMATTER_API_HOST` is likely incorrectly configured. Run `echo $GREYMATTER_API_HOST`, then run `sudo minikube service list` and check that the lower of the ports listed in voyager-edge matches the port at the end of your variable. (Newer versions of the helm charts pin the port to 30000, but older versions may have a different port.) If it doesn't match either voyager-edge port copy the first port and run `export PORT={your-voyager-edge-port}`. If one of them does match, try the other port. Then run the following,
 
     ```bash
     export HOST=$( curl -s http://169.254.169.254/latest/meta-data/public-ipv4 )


### PR DESCRIPTION
As I understand it, updates to GM Proxy have made cipher_suites an important field, and the 2.0.4 helm charts provide invalid cipher_suites. The latest helm charts don't, so the fix to make the training material good again is to update to the latest helm charts, 2.1.5.